### PR TITLE
fix: add unknown package manager callback

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,12 +7,14 @@ import { AGENTS, LOCKS } from './agents'
 
 export interface DetectOptions {
   cwd?: string
+  /* callback when pm unknown from package.json */
+  unknownPackageManager?: (packageManager: string) => void
 }
 
 export type { Agent }
 export { AGENTS, LOCKS }
 
-export async function detect({ cwd }: DetectOptions = {}) {
+export async function detect({ cwd, unknownPackageManager }: DetectOptions = {}) {
   let agent: Agent | undefined
   let version: string | undefined
 
@@ -41,6 +43,9 @@ export async function detect({ cwd }: DetectOptions = {}) {
         }
         else if (AGENTS.includes(name)) {
           agent = name
+        }
+        else {
+          unknownPackageManager?.(pkg.packageManager)
         }
       }
     }


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
This PR adds `unknownPackageManager` when unknown from package.json to allow show warning in `ni` and `@antfu/install-pkg`

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
