### PR TITLE
fix!: improve detect algorithm, `detect` runs `null` when dismatch, fix #9

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -28,20 +28,16 @@ export async function detect({ cwd, onUnknown }: DetectOptions = {}) {
       if (await fileExists(path.join(directory, lock))) {
         agent = LOCKS[lock]
         const result = await parsePackageJson(path.join(directory, 'package.json'), onUnknown)
-        if (result) {
-          agent = result.agent
-          version = result.version
-        }
-        break
+        if (result)
+          return result
+        else
+          return { agent, version }
       }
     }
     // Look up for package.json
     const result = await parsePackageJson(path.join(directory, 'package.json'), onUnknown)
-    if (result) {
-      agent = result.agent
-      version = result.version
-      break
-    }
+    if (result)
+      return result
   }
 
   return { agent, version }

--- a/test/__snapshots__/detect.spec.ts.snap
+++ b/test/__snapshots__/detect.spec.ts.snap
@@ -3,49 +3,38 @@
 exports[`lockfile > bun 1`] = `
 {
   "agent": "bun",
-  "version": undefined,
 }
 `;
 
 exports[`lockfile > npm 1`] = `
 {
   "agent": "npm",
-  "version": undefined,
 }
 `;
 
 exports[`lockfile > pnpm 1`] = `
 {
   "agent": "pnpm",
-  "version": undefined,
 }
 `;
 
 exports[`lockfile > pnpm@6 1`] = `
 {
   "agent": "pnpm",
-  "version": undefined,
 }
 `;
 
-exports[`lockfile > unknown 1`] = `
-{
-  "agent": undefined,
-  "version": undefined,
-}
-`;
+exports[`lockfile > unknown 1`] = `null`;
 
 exports[`lockfile > yarn 1`] = `
 {
   "agent": "yarn",
-  "version": undefined,
 }
 `;
 
 exports[`lockfile > yarn@berry 1`] = `
 {
   "agent": "yarn",
-  "version": undefined,
 }
 `;
 
@@ -77,12 +66,7 @@ exports[`packager > pnpm@6 1`] = `
 }
 `;
 
-exports[`packager > unknown 1`] = `
-{
-  "agent": undefined,
-  "version": undefined,
-}
-`;
+exports[`packager > unknown 1`] = `null`;
 
 exports[`packager > yarn 1`] = `
 {


### PR DESCRIPTION
Change to scan the lock and package.json at the same time and return the first match. Ideally it would be sightly more efficient as the lookup will only happen once now