### PR TITLE
feat: add command to execute local binaries

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -49,7 +49,7 @@ const bun: AgentCommands = {
   'upgrade': ['bun', 'update', 0],
   'upgrade-interactive': ['bun', 'update', 0],
   'execute': ['bun', 'x', 0],
-  'execute-local': ['bun', 'x', 0],
+  'execute-local': ['bun', 0],
   'uninstall': ['bun', 'remove', 0],
   'global_uninstall': ['bun', 'remove', '-g', 0],
 }
@@ -65,7 +65,7 @@ export const COMMANDS = {
     'upgrade': ['npm', 'update', 0],
     'upgrade-interactive': null,
     'execute': ['npx', 0],
-    'execute-local': ['npm', 'exec', 0],
+    'execute-local': ['npx', 0],
     'uninstall': ['npm', 'uninstall', 0],
     'global_uninstall': ['npm', 'uninstall', '-g', 0],
   },

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -21,7 +21,7 @@ const yarn: AgentCommands = {
   'upgrade': ['yarn', 'upgrade', 0],
   'upgrade-interactive': ['yarn', 'upgrade-interactive', 0],
   'execute': ['npx', 0],
-  'execute-local': ['yarn', 0],
+  'execute-local': ['yarn', 'exec', 0],
   'uninstall': ['yarn', 'remove', 0],
   'global_uninstall': ['yarn', 'global', 'remove', 0],
 }
@@ -35,7 +35,7 @@ const pnpm: AgentCommands = {
   'upgrade': ['pnpm', 'update', 0],
   'upgrade-interactive': ['pnpm', 'update', '-i', 0],
   'execute': ['pnpm', 'dlx', 0],
-  'execute-local': ['pnpm', 0],
+  'execute-local': ['pnpm', 'exec', 0],
   'uninstall': ['pnpm', 'remove', 0],
   'global_uninstall': ['pnpm', 'remove', '--global', 0],
 }
@@ -49,7 +49,7 @@ const bun: AgentCommands = {
   'upgrade': ['bun', 'update', 0],
   'upgrade-interactive': ['bun', 'update', 0],
   'execute': ['bun', 'x', 0],
-  'execute-local': ['bun', 0],
+  'execute-local': ['bun', 'x', 0],
   'uninstall': ['bun', 'remove', 0],
   'global_uninstall': ['bun', 'remove', '-g', 0],
 }
@@ -76,7 +76,7 @@ export const COMMANDS = {
     'upgrade': ['yarn', 'up', 0],
     'upgrade-interactive': ['yarn', 'up', '-i', 0],
     'execute': ['yarn', 'dlx', 0],
-    'execute-local': ['yarn', 0],
+    'execute-local': ['yarn', 'exec', 0],
     // Yarn 2+ removed 'global', see https://github.com/yarnpkg/berry/issues/821
     'global': ['npm', 'i', '-g', 0],
     'global_uninstall': ['npm', 'uninstall', '-g', 0],

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -21,6 +21,7 @@ const yarn: AgentCommands = {
   'upgrade': ['yarn', 'upgrade', 0],
   'upgrade-interactive': ['yarn', 'upgrade-interactive', 0],
   'execute': ['npx', 0],
+  'execute-local': ['yarn', 0],
   'uninstall': ['yarn', 'remove', 0],
   'global_uninstall': ['yarn', 'global', 'remove', 0],
 }
@@ -34,6 +35,7 @@ const pnpm: AgentCommands = {
   'upgrade': ['pnpm', 'update', 0],
   'upgrade-interactive': ['pnpm', 'update', '-i', 0],
   'execute': ['pnpm', 'dlx', 0],
+  'execute-local': ['pnpm', 'exec', 0],
   'uninstall': ['pnpm', 'remove', 0],
   'global_uninstall': ['pnpm', 'remove', '--global', 0],
 }
@@ -47,6 +49,7 @@ const bun: AgentCommands = {
   'upgrade': ['bun', 'update', 0],
   'upgrade-interactive': ['bun', 'update', 0],
   'execute': ['bun', 'x', 0],
+  'execute-local': ['bun', 'x', 0],
   'uninstall': ['bun', 'remove', 0],
   'global_uninstall': ['bun', 'remove', '-g', 0],
 }
@@ -62,6 +65,7 @@ export const COMMANDS = {
     'upgrade': ['npm', 'update', 0],
     'upgrade-interactive': null,
     'execute': ['npx', 0],
+    'execute-local': ['npm', 'exec', 0],
     'uninstall': ['npm', 'uninstall', 0],
     'global_uninstall': ['npm', 'uninstall', '-g', 0],
   },
@@ -72,6 +76,7 @@ export const COMMANDS = {
     'upgrade': ['yarn', 'up', 0],
     'upgrade-interactive': ['yarn', 'up', '-i', 0],
     'execute': ['yarn', 'dlx', 0],
+    'execute-local': ['yarn', 'exec', 0],
     // Yarn 2+ removed 'global', see https://github.com/yarnpkg/berry/issues/821
     'global': ['npm', 'i', '-g', 0],
     'global_uninstall': ['npm', 'uninstall', '-g', 0],

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -21,7 +21,7 @@ const yarn: AgentCommands = {
   'upgrade': ['yarn', 'upgrade', 0],
   'upgrade-interactive': ['yarn', 'upgrade-interactive', 0],
   'execute': ['npx', 0],
-  'execute-local': ['yarn', 0],
+  'execute-local': ['yarn', 'exec', 0],
   'uninstall': ['yarn', 'remove', 0],
   'global_uninstall': ['yarn', 'global', 'remove', 0],
 }

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -21,7 +21,7 @@ const yarn: AgentCommands = {
   'upgrade': ['yarn', 'upgrade', 0],
   'upgrade-interactive': ['yarn', 'upgrade-interactive', 0],
   'execute': ['npx', 0],
-  'execute-local': ['yarn', 'exec', 0],
+  'execute-local': ['yarn', 0],
   'uninstall': ['yarn', 'remove', 0],
   'global_uninstall': ['yarn', 'global', 'remove', 0],
 }
@@ -35,7 +35,7 @@ const pnpm: AgentCommands = {
   'upgrade': ['pnpm', 'update', 0],
   'upgrade-interactive': ['pnpm', 'update', '-i', 0],
   'execute': ['pnpm', 'dlx', 0],
-  'execute-local': ['pnpm', 'exec', 0],
+  'execute-local': ['pnpm', 0],
   'uninstall': ['pnpm', 'remove', 0],
   'global_uninstall': ['pnpm', 'remove', '--global', 0],
 }
@@ -76,7 +76,7 @@ export const COMMANDS = {
     'upgrade': ['yarn', 'up', 0],
     'upgrade-interactive': ['yarn', 'up', '-i', 0],
     'execute': ['yarn', 'dlx', 0],
-    'execute-local': ['yarn', 'exec', 0],
+    'execute-local': ['yarn', 0],
     // Yarn 2+ removed 'global', see https://github.com/yarnpkg/berry/issues/821
     'global': ['npm', 'i', '-g', 0],
     'global_uninstall': ['npm', 'uninstall', '-g', 0],

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,6 +13,7 @@ export interface AgentCommands {
   'upgrade': AgentCommandValue
   'upgrade-interactive': AgentCommandValue
   'execute': AgentCommandValue
+  'execute-local': AgentCommandValue
   'uninstall': AgentCommandValue
   'global_uninstall': AgentCommandValue
 }


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

This PR adds a new command, `execute-local`, that focuses on executing local binaries. While `execute` already exists, it prioritizes on downloading and executing remote binaries (i.e. it uses `pnpm dlx` and `yarn dlx`). 

Ideally, `execute` could be renamed to `dlx` and `execute-local` could take the `execute` name, but that'd be a breaking change.

### Linked Issues
n/a

### Additional context

n/a
