### PR TITLE
feat: add deno as package manager

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -54,6 +54,21 @@ const bun: AgentCommands = {
   'global_uninstall': ['bun', 'remove', '-g', 0],
 }
 
+const deno: AgentCommands = {
+  'agent': ['deno', 0],
+  'run': ['deno', 'run', 0],
+  'install': ['deno', 'install', 0],
+  'frozen': ['deno', 'install', '--frozen'],
+  'global': ['deno', 'install', '-g', 0],
+  'add': ['deno', 'add', 0],
+  'upgrade': ['deno', 'update', 0],
+  'upgrade-interactive': ['deno', 'update', 0],
+  'execute': ['deno', 'run', 0],
+  'execute-local': ['deno', 'run', 0],
+  'uninstall': ['deno', 'remove', 0],
+  'global_uninstall': ['deno', 'uninstall', '-g', 0],
+}
+
 export const COMMANDS = {
   'npm': <AgentCommands>{
     'agent': ['npm', 0],
@@ -88,6 +103,7 @@ export const COMMANDS = {
     run: npmRun('pnpm'),
   },
   'bun': bun,
+  'deno': deno,
 } satisfies Record<Agent, AgentCommands>
 
 /**

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -7,11 +7,13 @@ export const AGENTS: Agent[] = [
   'pnpm',
   'pnpm@6',
   'bun',
+  'deno',
 ]
 
 // the order here matters, more specific one comes first
 export const LOCKS: Record<string, AgentName> = {
   'bun.lockb': 'bun',
+  'deno.lock': 'deno',
   'pnpm-lock.yaml': 'pnpm',
   'yarn.lock': 'yarn',
   'package-lock.json': 'npm',
@@ -20,6 +22,7 @@ export const LOCKS: Record<string, AgentName> = {
 
 export const INSTALL_PAGE: Record<Agent, string> = {
   'bun': 'https://bun.sh',
+  'deno': 'https://deno.com',
   'pnpm': 'https://pnpm.io/installation',
   'pnpm@6': 'https://pnpm.io/6.x/installation',
   'yarn': 'https://classic.yarnpkg.com/en/docs/install',

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
-export type Agent = 'npm' | 'yarn' | 'yarn@berry' | 'pnpm' | 'pnpm@6' | 'bun'
-export type AgentName = 'npm' | 'yarn' | 'pnpm' | 'bun'
+export type Agent = 'npm' | 'yarn' | 'yarn@berry' | 'pnpm' | 'pnpm@6' | 'bun' | 'deno'
+export type AgentName = 'npm' | 'yarn' | 'pnpm' | 'bun' | 'deno'
 
 export type AgentCommandValue = (string | number)[] | ((args?: string[]) => string[]) | null
 
@@ -48,7 +48,7 @@ export interface DetectResult {
   /**
    * Agent name without the specifier.
    *
-   * Can be `npm`, `yarn`, `pnpm`, or `bun`.
+   * Can be `npm`, `yarn`, `pnpm`, `bun`, or `deno`.
    */
   name: AgentName
   /**

--- a/test/__snapshots__/command.spec.ts.snap
+++ b/test/__snapshots__/command.spec.ts.snap
@@ -22,6 +22,28 @@ exports[`test bun run command > command handles args correctly 1`] = `
 }
 `;
 
+exports[`test deno add command > command handles args correctly 1`] = `
+{
+  "args": [
+    "add",
+    "@antfu/ni",
+    "-D",
+  ],
+  "command": "deno",
+}
+`;
+
+exports[`test deno run command > command handles args correctly 1`] = `
+{
+  "args": [
+    "run",
+    "arg0",
+    "arg1-0 arg1-1",
+  ],
+  "command": "deno",
+}
+`;
+
 exports[`test npm add command > command handles args correctly 1`] = `
 {
   "args": [

--- a/test/__snapshots__/detect-sync.spec.ts.snap
+++ b/test/__snapshots__/detect-sync.spec.ts.snap
@@ -7,6 +7,13 @@ exports[`lockfile > bun 1`] = `
 }
 `;
 
+exports[`lockfile > deno 1`] = `
+{
+  "agent": "deno",
+  "name": "deno",
+}
+`;
+
 exports[`lockfile > npm 1`] = `
 {
   "agent": "npm",
@@ -45,6 +52,14 @@ exports[`lockfile > yarn@berry 1`] = `
 `;
 
 exports[`packager > bun 1`] = `
+{
+  "agent": "bun",
+  "name": "bun",
+  "version": "0",
+}
+`;
+
+exports[`packager > deno 1`] = `
 {
   "agent": "bun",
   "name": "bun",

--- a/test/__snapshots__/detect-sync.spec.ts.snap
+++ b/test/__snapshots__/detect-sync.spec.ts.snap
@@ -61,9 +61,9 @@ exports[`packager > bun 1`] = `
 
 exports[`packager > deno 1`] = `
 {
-  "agent": "bun",
-  "name": "bun",
-  "version": "0",
+  "agent": "deno",
+  "name": "deno",
+  "version": "2",
 }
 `;
 

--- a/test/__snapshots__/detect.spec.ts.snap
+++ b/test/__snapshots__/detect.spec.ts.snap
@@ -7,6 +7,13 @@ exports[`lockfile > bun 1`] = `
 }
 `;
 
+exports[`lockfile > deno 1`] = `
+{
+  "agent": "deno",
+  "name": "deno",
+}
+`;
+
 exports[`lockfile > npm 1`] = `
 {
   "agent": "npm",
@@ -45,6 +52,14 @@ exports[`lockfile > yarn@berry 1`] = `
 `;
 
 exports[`packager > bun 1`] = `
+{
+  "agent": "bun",
+  "name": "bun",
+  "version": "0",
+}
+`;
+
+exports[`packager > deno 1`] = `
 {
   "agent": "bun",
   "name": "bun",

--- a/test/__snapshots__/detect.spec.ts.snap
+++ b/test/__snapshots__/detect.spec.ts.snap
@@ -61,9 +61,9 @@ exports[`packager > bun 1`] = `
 
 exports[`packager > deno 1`] = `
 {
-  "agent": "bun",
-  "name": "bun",
-  "version": "0",
+  "agent": "deno",
+  "name": "deno",
+  "version": "2",
 }
 `;
 

--- a/test/fixtures/packager/deno/package.json
+++ b/test/fixtures/packager/deno/package.json
@@ -1,3 +1,3 @@
 {
-  "packageManager": "deno"
+  "packageManager": "deno@2"
 }

--- a/test/fixtures/packager/deno/package.json
+++ b/test/fixtures/packager/deno/package.json
@@ -1,0 +1,3 @@
+{
+  "packageManager": "deno"
+}

--- a/test/user-agent.spec.ts
+++ b/test/user-agent.spec.ts
@@ -10,6 +10,7 @@ describe('get user agent', () => {
     ['yarn', 'yarn/1.22.11 npm/? node/v14.17.6 darwin x64'],
     ['pnpm', 'pnpm/9.12.1 npm/? node/v20.17.0 linux x64'],
     ['bun', 'bun/1.1.8 npm/? node/v21.6.0 linux x64'],
+    ['deno', 'deno/2.0.5 npm/? node/v21.6.0 linux x64'],
   ].forEach(([agent, detection]) => {
     it(`${agent} detected with ${detection}`, () => {
       vi.stubEnv(


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Add Deno as a valid package manager recognized by `package-manager-detector`.

### Linked Issues

Closes https://github.com/antfu-collective/package-manager-detector/issues/21

### Additional context

As of Deno v2.0.5, Deno will provide `npm_config_user_agent` env var in relevant subcommands (https://github.com/denoland/deno/pull/26639).
