### PR TITLE
fix: Change 'run' command for Deno to prepend 'npm:' prefix

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -13,7 +13,7 @@ function npmRun(agent: string) {
 
 function denoRun() {
   return (args: string[]) => {
-    return ['deno', 'run', `npm"${args[0]}`, ...args.slice(1)]
+    return ['deno', 'run', `npm:${args[0]}`, ...args.slice(1)]
   }
 }
 

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -11,6 +11,12 @@ function npmRun(agent: string) {
   }
 }
 
+function denoRun() {
+  return (args: string[]) => {
+    return ['deno', 'run', `npm"${args[0]}`, ...args.slice(1)]
+  }
+}
+
 const npm: AgentCommands = {
   'agent': ['npm', 0],
   'run': npmRun('npm'),
@@ -87,7 +93,7 @@ const bun: AgentCommands = {
 
 const deno: AgentCommands = {
   'agent': ['deno', 0],
-  'run': ['deno', 'run', 0],
+  'run': denoRun(),
   'install': ['deno', 'install', 0],
   'frozen': ['deno', 'install', '--frozen'],
   'global': ['deno', 'install', '-g', 0],

--- a/test/__snapshots__/command.spec.ts.snap
+++ b/test/__snapshots__/command.spec.ts.snap
@@ -37,7 +37,7 @@ exports[`test deno run command > command handles args correctly 1`] = `
 {
   "args": [
     "run",
-    "arg0",
+    "npm:arg0",
     "arg1-0 arg1-1",
   ],
   "command": "deno",


### PR DESCRIPTION
### Description

This commit changes "run" command for Deno to prepend `npm:` prefix
to the first argument.

### Linked Issues

As discussed with @benmccann in https://github.com/sveltejs/cli/pull/313#issuecomment-2498682845.