### PR TITLE
fix: correct AgentCommandValue type

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,8 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - name: Install
         run: pnpm install
+      - name: Build
+        run: pnpm build
       - name: Lint
         run: pnpm run lint
       - name: Test

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,7 @@
 export type Agent = 'npm' | 'yarn' | 'yarn@berry' | 'pnpm' | 'pnpm@6' | 'bun' | 'deno'
 export type AgentName = 'npm' | 'yarn' | 'pnpm' | 'bun' | 'deno'
 
-export type AgentCommandValue = (string | number)[] | ((args?: string[]) => string[]) | null
+export type AgentCommandValue = (string | number)[] | ((args: string[]) => string[]) | null
 
 export interface AgentCommands {
   'agent': AgentCommandValue


### PR DESCRIPTION
I pulled the project locally after merging https://github.com/antfu-collective/package-manager-detector/pull/34 and tried to build it and the build failed. This fixes it and also updates the CI to build the project so that we don't miss things like that in the future