### PR TITLE
fix: point to the latest install page for npm

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -28,5 +28,5 @@ export const INSTALL_PAGE: Record<Agent, string> = {
   'pnpm@6': 'https://pnpm.io/6.x/installation',
   'yarn': 'https://classic.yarnpkg.com/en/docs/install',
   'yarn@berry': 'https://yarnpkg.com/getting-started/install',
-  'npm': 'https://docs.npmjs.com/cli/v8/configuring-npm/install',
+  'npm': 'https://docs.npmjs.com/cli/configuring-npm/install',
 }


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

The constant doesn’t seem to be in use (yet), but because `npm@v8` is a legacy version I made it so that it always point to the latest npm install docs.

### Linked Issues

**N/A**

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

**N/A**

---

💖
