### PR TITLE
chore: add bun install instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ npm i package-manager-detector
 yarn add package-manager-detector
 ```
 
+**using bun**
+
+```sh
+bun install
+```
+
 ## Usage
 
 ### ESM


### PR DESCRIPTION
Updated the installation instructions to include bun install v1.2.5-canary.71 (60eb2c4e)

Checked 496 installs across 546 packages (no changes) [75.00ms] as an option.