### PR TITLE
docs: add custom detect strategies section

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ import { getUserAgent } from 'package-manager-detector/detect'
 
 ## Customize Detection Strategy
 
-By default, the `detect` API searches through the current directory for lock files, and if none exists, the `package.json` `packageManager` field. If both strategy couldn't detect the package manager, it'll crawl upwards to the parent directory and repeat the detection process until it reaches the root directory.
+By default, the `detect` API searches through the current directory for lock files, and if none exists, the `package.json` `packageManager` field. If both strategies couldn't detect the package manager, it'll crawl upwards to the parent directory and repeat the detection process until it reaches the root directory.
 
 The strategies can be configured through `detect`'s `strategies` option with the following accepted strategies:
 

--- a/README.md
+++ b/README.md
@@ -24,8 +24,6 @@ yarn add package-manager-detector
 
 ## Usage
 
-### ESM
-
 To check the file system for which package manager is used:
 
 ```js
@@ -36,6 +34,26 @@ or to get the currently running package manager:
 
 ```js
 import { getUserAgent } from 'package-manager-detector/detect'
+```
+
+## Customize Detection Strategy
+
+By default, the `detect` API searches through the current directory for lock files, and if none exists, the `package.json` `packageManager` field. If both strategy couldn't detect the package manager, it'll crawl upwards to the parent directory and repeat the detection process until it reaches the root directory.
+
+The strategies can be configured through `detect`'s `strategies` option with the following accepted strategies:
+
+- `'lockfile'`: Look up for lock files.
+- `'packageManager-field'`: Look up for the `packageManager` field in package.json.
+- `'install-metadata'`: Look up for installation metadata added by package managers.
+
+The order of the strategies can also be changed to prioritize one strategy over another. For example, if you prefer to detect the package manager used for installation:
+
+```js
+import { detect } from 'package-manager-detector/detect'
+
+const pm = await detect({
+  strategies: ['install-metadata', 'lockfile', 'packageManager-field']
+})
 ```
 
 ## Agents and Commands

--- a/src/types.ts
+++ b/src/types.ts
@@ -44,9 +44,9 @@ export interface DetectOptions {
    * are executed in the order it's specified for every directory that it iterates
    * upwards from the `cwd`.
    *
-   * - `lockfile`: Look up for lock files.
-   * - `packageManager-field`: Look up for the `packageManager` field in package.json.
-   * - `install-metadata`: Look up for installation metadata added by package managers.
+   * - `'lockfile'`: Look up for lock files.
+   * - `'packageManager-field'`: Look up for the `packageManager` field in package.json.
+   * - `'install-metadata'`: Look up for installation metadata added by package managers.
    *
    * @default ['lockfile', 'packageManager-field']
    */


### PR DESCRIPTION

### Description

Documents the `strategies` option added in #42. I didn't document the other options generally, like `cwd` and `onUnknown`, I think they're self-explanatory edgecasey enough that the jsdocs might be enough, but I'm happy to document those too if preferred.

### Linked Issues

ref https://github.com/antfu-collective/package-manager-detector/pull/42#issuecomment-2710642597

cc @userquin 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
