### PR TITLE
feat: use --npm for deno add command (#51)

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -96,7 +96,7 @@ const deno: AgentCommands = {
   'install': ['deno', 'install', 0],
   'frozen': ['deno', 'install', '--frozen', 0],
   'global': ['deno', 'install', '-g', 0],
-  'add': ['deno', 'add', 0],
+  'add': ['deno', 'add', '--npm', 0],
   'upgrade': ['deno', 'outdated', '--update', 0],
   'upgrade-interactive': ['deno', 'outdated', '--update', 0],
   'dedupe': null,

--- a/test/__snapshots__/command.spec.ts.snap
+++ b/test/__snapshots__/command.spec.ts.snap
@@ -37,6 +37,7 @@ exports[`test deno add command > command handles args correctly 1`] = `
 {
   "args": [
     "add",
+    "--npm",
     "@antfu/ni",
     "-D",
   ],


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

---

> Please be aware that vibe-coding contributions are **🚫 STRICTLY PROHIBITED**. 
> We are humans behind these open source projects, trying hard to maintain good quality and a healthy community. 
> Not only do vibe-coding contributions pollute the code, but they also drain A LOT of unnecessary energy and time from maintainers and toxify the community and collaboration.
>
> All vibe-coded, AI-generated PRs will be rejected and closed without further notice. In severe cases, your account might be banned organization-wide and reported to GitHub.
>
> **PLEASE SHOW SOME RESPECT** and do not do so.

---

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving and **WHY**, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

- [x] <- Keep this line and put an `x` between the brackts.

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving, and "WHY" -->
Use the `--npm` flag for Deno `add` command
This flag makes it treat unprefixed packages as npm packages
Prefixes can also still be used
This way passing just package names like with other package managers works

### Linked Issues

fixes #51

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
This flag was introduced in [Deno 2.3](https://deno.com/blog/v2.3#registry-flags-for-deno-add)
