### PR TITLE
fix(commands): preserve value-taking flags before script name in dashDashArg

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,19 +1,34 @@
 import type { Agent, AgentCommands, AgentCommandValue, Command, ResolvedCommand } from './types'
 
-function dashDashArg(agent: string, agentCommand: string) {
+function dashDashArg(agent: string, agentCommand: string, valueFlags: string[] = []) {
   return (args: string[]) => {
-    if (args.length > 1) {
-      return [agent, agentCommand, args[0], '--', ...args.slice(1)]
+    // Find the script name: the first positional arg that isn't a flag
+    // and isn't the value of a preceding value-taking flag (e.g. `-w foo`).
+    let scriptIdx = -1
+    for (let i = 0; i < args.length; i++) {
+      if (args[i].startsWith('-'))
+        continue
+      const prev = i > 0 ? args[i - 1] : undefined
+      if (prev !== undefined && valueFlags.includes(prev))
+        continue
+      scriptIdx = i
+      break
     }
-    else {
-      return [agent, agentCommand, args[0]]
-    }
+    if (scriptIdx === -1)
+      return [agent, agentCommand, ...args]
+
+    const before = args.slice(0, scriptIdx)
+    const script = args[scriptIdx]
+    const after = args.slice(scriptIdx + 1)
+    if (after.length > 0)
+      return [agent, agentCommand, ...before, script, '--', ...after]
+    return [agent, agentCommand, ...before, script]
   }
 }
 
 const npm: AgentCommands = {
   'agent': ['npm', 0],
-  'run': dashDashArg('npm', 'run'),
+  'run': dashDashArg('npm', 'run', ['-w', '--workspace']),
   'install': ['npm', 'i', 0],
   'frozen': ['npm', 'ci', 0],
   'global': ['npm', 'i', '-g', 0],
@@ -114,7 +129,7 @@ export const COMMANDS = {
   // pnpm v6.x or below
   'pnpm@6': <AgentCommands>{
     ...pnpm,
-    run: dashDashArg('pnpm', 'run'),
+    run: dashDashArg('pnpm', 'run', ['-F', '--filter']),
   },
   'bun': bun,
   'deno': deno,

--- a/test/command.spec.ts
+++ b/test/command.spec.ts
@@ -26,3 +26,40 @@ Object.entries(COMMANDS)
       })
     })
   })
+
+describe('npm run workspace flag handling', () => {
+  it('keeps `-w <value>` together with the script name (no unwanted `--`)', () => {
+    const resolved = resolveCommand('npm', 'run', ['-w', 'packages/foo', 'test'])
+    expect(resolved).toEqual({ command: 'npm', args: ['run', '-w', 'packages/foo', 'test'] })
+  })
+
+  it('keeps `--workspace <value>` together with the script name', () => {
+    const resolved = resolveCommand('npm', 'run', ['--workspace', 'packages/foo', 'test'])
+    expect(resolved).toEqual({ command: 'npm', args: ['run', '--workspace', 'packages/foo', 'test'] })
+  })
+
+  it('passes script args after the script through `--`', () => {
+    const resolved = resolveCommand('npm', 'run', ['-w', 'packages/foo', 'test', '--grep', 'bar'])
+    expect(resolved).toEqual({
+      command: 'npm',
+      args: ['run', '-w', 'packages/foo', 'test', '--', '--grep', 'bar'],
+    })
+  })
+
+  it('still supports `-w=<value>` form', () => {
+    const resolved = resolveCommand('npm', 'run', ['-w=packages/foo', 'test'])
+    expect(resolved).toEqual({ command: 'npm', args: ['run', '-w=packages/foo', 'test'] })
+  })
+
+  it('handles `-w` without explicit value (treated as boolean-ish)', () => {
+    const resolved = resolveCommand('npm', 'run', ['--if-present', 'test'])
+    expect(resolved).toEqual({ command: 'npm', args: ['run', '--if-present', 'test'] })
+  })
+})
+
+describe('pnpm@6 run filter flag handling', () => {
+  it('keeps `-F <value>` together with the script name', () => {
+    const resolved = resolveCommand('pnpm@6', 'run', ['-F', 'packages/foo', 'test'])
+    expect(resolved).toEqual({ command: 'pnpm', args: ['run', '-F', 'packages/foo', 'test'] })
+  })
+})


### PR DESCRIPTION
## Summary

`dashDashArg` (used for `npm run` and `pnpm@6 run`) previously treated `args[0]` as the script name unconditionally. That breaks value-taking flags passed positionally:

```
nr -w packages/foo test
# → npm run -w -- packages/foo test
# → npm errors: "No workspaces found: --workspace=true"
```

This PR scans for the first positional arg that is neither a flag nor the value of a preceding value-taking flag, and treats that as the script name. Flags before the script stay in front; script args after it still go through `--`.

Registered value-taking flags:
- npm: `-w`, `--workspace`
- pnpm@6: `-F`, `--filter`

## Before / After

| Input (`nr …`) | Before | After |
| --- | --- | --- |
| `-w packages/foo test` | `npm run -w -- packages/foo test` ❌ | `npm run -w packages/foo test` ✅ |
| `--workspace packages/foo test` | `npm run --workspace -- packages/foo test` ❌ | `npm run --workspace packages/foo test` ✅ |
| `-w packages/foo test --grep bar` | broken | `npm run -w packages/foo test -- --grep bar` ✅ |
| `arg0 arg1` (unchanged) | `npm run arg0 -- arg1` | `npm run arg0 -- arg1` |

Existing snapshots remain unchanged.

## Test plan

- [x] `pnpm test` — 76 tests pass (5 new cases covering `-w <v>`, `--workspace <v>`, script-args after script, existing `-w=<v>` form, and a boolean flag like `--if-present`; plus `-F <v>` for pnpm@6)
- [x] `pnpm build`
- [x] `pnpm lint`

Fixes antfu-collective/ni#322
Refs #58