### PR TITLE
feat: detect nub package manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 Package manager detector is based on lock files, the `package.json` `packageManager` field, and installation metadata to detect the package manager used in a project.
 
-It supports `npm`, `yarn`, `pnpm`, `deno`, and `bun`.
+It supports `npm`, `yarn`, `pnpm`, `deno`, `bun`, and `nub`.
 
 ## Install
 

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -106,6 +106,24 @@ const deno: AgentCommands = {
   'global_uninstall': ['deno', 'uninstall', '-g', 0],
 }
 
+// nub's package-manager CLI is pnpm-compatible; `execute` (dlx) is the
+// dedicated `nubx` binary, not a `nub` subcommand.
+const nub: AgentCommands = {
+  'agent': ['nub', 0],
+  'run': ['nub', 'run', 0],
+  'install': ['nub', 'install', 0],
+  'frozen': ['nub', 'install', '--frozen-lockfile', 0],
+  'global': ['nub', 'add', '-g', 0],
+  'add': ['nub', 'add', 0],
+  'upgrade': ['nub', 'update', 0],
+  'upgrade-interactive': ['nub', 'update', '-i', 0],
+  'dedupe': ['nub', 'dedupe', 0],
+  'execute': ['nubx', 0],
+  'execute-local': ['nub', 'exec', 0],
+  'uninstall': ['nub', 'remove', 0],
+  'global_uninstall': ['nub', 'remove', '-g', 0],
+}
+
 export const COMMANDS = {
   'npm': npm,
   'yarn': yarn,
@@ -118,6 +136,7 @@ export const COMMANDS = {
   },
   'bun': bun,
   'deno': deno,
+  'nub': nub,
 } satisfies Record<Agent, AgentCommands>
 
 /**

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -106,8 +106,10 @@ const deno: AgentCommands = {
   'global_uninstall': ['deno', 'uninstall', '-g', 0],
 }
 
-// nub's package-manager CLI is pnpm-compatible; `execute` (dlx) is the
-// dedicated `nubx` binary, not a `nub` subcommand.
+// nub mirrors pnpm's CLI grammar, with two deliberate divergences encoded
+// here: `upgrade` maps to `nub update` (nub reserves `nub upgrade` for its
+// own self-update, which rejects a package argument), and `execute` (dlx) is
+// the dedicated `nubx` binary, not a `nub` subcommand.
 const nub: AgentCommands = {
   'agent': ['nub', 0],
   'run': ['nub', 'run', 0],

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -8,6 +8,7 @@ export const AGENTS: Agent[] = [
   'pnpm@6',
   'bun',
   'deno',
+  'nub',
 ]
 
 // the order here matters, more specific one comes first
@@ -43,4 +44,5 @@ export const INSTALL_PAGE: Record<Agent, string> = {
   'yarn': 'https://classic.yarnpkg.com/en/docs/install',
   'yarn@berry': 'https://yarnpkg.com/getting-started/install',
   'npm': 'https://docs.npmjs.com/cli/configuring-npm/install',
+  'nub': 'https://nubjs.com/docs/install',
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
-export type Agent = 'npm' | 'yarn' | 'yarn@berry' | 'pnpm' | 'pnpm@6' | 'bun' | 'deno'
-export type AgentName = 'npm' | 'yarn' | 'pnpm' | 'bun' | 'deno'
+export type Agent = 'npm' | 'yarn' | 'yarn@berry' | 'pnpm' | 'pnpm@6' | 'bun' | 'deno' | 'nub'
+export type AgentName = 'npm' | 'yarn' | 'pnpm' | 'bun' | 'deno' | 'nub'
 
 export type AgentCommandValue = (string | number)[] | ((args: string[]) => string[]) | null
 
@@ -81,7 +81,7 @@ export interface DetectResult {
   /**
    * Agent name without the specifier.
    *
-   * Can be `npm`, `yarn`, `pnpm`, `bun`, or `deno`.
+   * Can be `npm`, `yarn`, `pnpm`, `bun`, `deno`, or `nub`.
    */
   name: AgentName
   /**

--- a/test/__snapshots__/command.spec.ts.snap
+++ b/test/__snapshots__/command.spec.ts.snap
@@ -99,6 +99,38 @@ exports[`test npm run command > command handles args correctly 1`] = `
 }
 `;
 
+exports[`test nub add command > command handles args correctly 1`] = `
+{
+  "args": [
+    "add",
+    "@antfu/ni",
+    "-D",
+  ],
+  "command": "nub",
+}
+`;
+
+exports[`test nub execute command > command handles args correctly 1`] = `
+{
+  "args": [
+    "eslint",
+    "--fix",
+  ],
+  "command": "nubx",
+}
+`;
+
+exports[`test nub run command > command handles args correctly 1`] = `
+{
+  "args": [
+    "run",
+    "arg0",
+    "arg1-0 arg1-1",
+  ],
+  "command": "nub",
+}
+`;
+
 exports[`test pnpm add command > command handles args correctly 1`] = `
 {
   "args": [

--- a/test/__snapshots__/detect.spec.ts.snap
+++ b/test/__snapshots__/detect.spec.ts.snap
@@ -24,6 +24,14 @@ exports[`dev-engines > npm 1`] = `
 }
 `;
 
+exports[`dev-engines > nub 1`] = `
+{
+  "agent": "nub",
+  "name": "nub",
+  "version": "0.2.4",
+}
+`;
+
 exports[`dev-engines > pnpm 1`] = `
 {
   "agent": "pnpm",
@@ -196,6 +204,14 @@ exports[`packager > npm 1`] = `
   "agent": "npm",
   "name": "npm",
   "version": "7",
+}
+`;
+
+exports[`packager > nub 1`] = `
+{
+  "agent": "nub",
+  "name": "nub",
+  "version": "0.2.4",
 }
 `;
 

--- a/test/fixtures/dev-engines/nub/package.json
+++ b/test/fixtures/dev-engines/nub/package.json
@@ -1,0 +1,8 @@
+{
+  "devEngines": {
+    "packageManager": {
+      "name": "nub",
+      "version": "0.2.4"
+    }
+  }
+}

--- a/test/fixtures/packager/nub/package.json
+++ b/test/fixtures/packager/nub/package.json
@@ -1,0 +1,3 @@
+{
+  "packageManager": "nub@0.2.4"
+}

--- a/test/user-agent.spec.ts
+++ b/test/user-agent.spec.ts
@@ -11,6 +11,7 @@ describe('get user agent', () => {
     ['pnpm', 'pnpm/9.12.1 npm/? node/v20.17.0 linux x64'],
     ['bun', 'bun/1.1.8 npm/? node/v21.6.0 linux x64'],
     ['deno', 'deno/2.0.5 npm/? node/v21.6.0 linux x64'],
+    ['nub', 'nub/0.2.4 npm/? node/v22.0.0 darwin arm64'],
   ].forEach(([agent, detection]) => {
     it(`${agent} detected with ${detection}`, () => {
       vi.stubEnv(


### PR DESCRIPTION
Adds [nub](https://nubjs.com) as a recognized agent.

nub is a Rust CLI with a pnpm-compatible package-manager grammar. Detection matches the existing agents: user agent `nub/<version>`, `packageManager: "nub@<version>"`, and `devEngines.packageManager`.

All 13 command mappings re-verified empirically against a real nub binary (v0.2.4) — each accepted and semantically correct, including the global add/remove (`-g`) round-trip. Two deliberate pnpm divergences: `execute` (dlx) maps to `nubx`; `upgrade` maps to `nub update` (`nub upgrade` is nub's self-update and rejects a package arg).

Data-only: widens `Agent`/`AgentName`, `AGENTS`, `COMMANDS`, `INSTALL_PAGE`; adds fixtures + a user-agent case. 76 tests pass; build + lint clean.
