### PR TITLE
feat: detect nub.lock lockfile

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -19,6 +19,7 @@ export const LOCKS: Record<string, AgentName> = {
   'bun.lock': 'bun',
   'bun.lockb': 'bun',
   'deno.lock': 'deno',
+  'nub.lock': 'nub',
   'pnpm-lock.yaml': 'pnpm',
   'pnpm-workspace.yaml': 'pnpm',
   'yarn.lock': 'yarn',

--- a/test/__snapshots__/detect.spec.ts.snap
+++ b/test/__snapshots__/detect.spec.ts.snap
@@ -175,6 +175,13 @@ exports[`lockfile > npm 1`] = `
 }
 `;
 
+exports[`lockfile > nub 1`] = `
+{
+  "agent": "nub",
+  "name": "nub",
+}
+`;
+
 exports[`lockfile > pnpm 1`] = `
 {
   "agent": "pnpm",


### PR DESCRIPTION
Adds `nub.lock` to the lockfile-detection map. Nub is a package manager whose native lockfile is `nub.lock` (pnpm-v9 YAML content under a nub-specific name); it previously reused other package managers' lockfiles, so nothing needed adding here. Now that it writes its own, this entry teaches the detector to recognize it, mirroring the existing bun/pnpm/deno lockfile entries.

Follow-up to #72, which registered nub as an agent (via the `packageManager` field and user-agent string) but omitted the lockfile entry, so `nub.lock` was not yet in `LOCKS`.

Changes (data-only):

- `src/constants.ts` — one `LOCKS` entry, `'nub.lock': 'nub'`, alphabetically slotted between `deno.lock` and `pnpm-lock.yaml`.
- `test/fixtures/lockfile/nub/nub.lock` — empty fixture, matching the other lockfile fixtures.
- `test/__snapshots__/detect.spec.ts.snap` — regenerated snapshot for the nub case.

Testing: `pnpm test` green (106 passed), `pnpm build` and `pnpm lint` clean.
